### PR TITLE
fix bugs for meta data read and update to apply to stock data update

### DIFF
--- a/doc/data_orgnization.md
+++ b/doc/data_orgnization.md
@@ -6,30 +6,32 @@ This file specifys the data organization in the database.
 
 The common information of all instruments are stored in the `instruments` table. The columns in the table are show in below table
 
-| Column Name   | Data Type      | Description                                                                                      |
-|---------------|----------------|--------------------------------------------------------------------------------------------------|
-| symbol        | str            | Trade Symbol at exchange                                                                         |
-| exchange      | Enum[Exchange] | Primary exchange / Trade route etc                                                               |
-| name          | str            | Instrument name                                                                                  |
-| inst_type     | Enum[InstType] | Instrument type                                                                                  |
-| currency      | str            | Quote currency                                                                                   |
-| timezone      | str            | Timezone                                                                                         |
-| tick_size     | float          | Instrument tick size                                                                             |
-| lot_size      | float          | Lot size                                                                                         |
-| min_lots      | float          | Minimum lots to trade                                                                            |
-| market_tplus  | int            | T+? can sell                                                                                     |
-| listed_date   | datetime       | Listed date                                                                                      |
-| delisted_date | datetime       | Delisted date                                                                                    |
+| Column Name   | Data Type      | Description                        |
+|---------------|----------------|------------------------------------|
+| ticker        | str            | Trade Symbol at exchange           |
+| exchange      | Enum[Exchange] | Primary exchange / Trade route etc |
+| trading_code  | str            | Trading code at exchange           |
+| name          | str            | Instrument name                    |
+| inst_type     | Enum[InstType] | Instrument type                    |
+| currency      | str            | Quote currency                     |
+| timezone      | str            | Timezone                           |
+| tick_size     | float          | Instrument tick size               |
+| lot_size      | float          | Lot size                           |
+| min_lots      | float          | Minimum lots to trade              |
+| market_tplus  | int            | T+? can sell                       |
+| listed_date   | datetime       | Listed date                        |
+| delisted_date | datetime       | Delisted date                      |
 
 <!--| stop_trading_date | datetime       | Date the contract removed from trading (Can be different of delisting date for some instruments) |-->
 
 The type-specific information are stored in tables named `instruments_<type>` where `<type>` is the type of the instrument (in lower case).
 Below table shows the columns in the type-specific tables (besides the symbol | exchange | currency column):
 
-| Enum[InstType]  | Columns    | Instrument Types which requires the column |
-|-----------------|------------|--------------------------------------------|
-| STK             | sector     | Sector of the company                      |
-|                 | industry   | Industry of the company                    |
-|                 | country    | Country                                    |
-|                 | state      | State/Province                             |
-|                 | board_type | Mainboard etc.                             |
+| Enum[InstType]  | Columns      | Instrument Types which requires the column |
+|-----------------|--------------|--------------------------------------------|
+| STK             | sector       | Sector of the company                      |
+|                 | industry     | Industry of the company                    |
+|                 | country      | Country                                    |
+|                 | state        | State/Province                             |
+|                 | board_type   | Mainboard etc.                             |
+|                 | issue_price  | Stock issuing price                        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trade_database_manager"
-version = "0.0.1.dev2"
+version = "0.0.1.dev4"
 description = "A wrapper of kdb and sql for convenient trade data management."
 readme = "README.md"
 authors = [
@@ -43,3 +43,7 @@ target-version = ['py310']
 [tool.isort]
 profile = "black"
 line_length = 120
+
+[tool.flake8]
+max-line-length = 120
+ignore = "E203,E501,W503"

--- a/trade_database_manager/manager/__init__.py
+++ b/trade_database_manager/manager/__init__.py
@@ -3,3 +3,7 @@
 # @Author  : YQ Tsui
 # @File    : __init__.py
 # @Purpose :
+
+from .metadata_sql import MetadataSql
+
+__all__ = ("MetadataSql",)


### PR DESCRIPTION
1. Add `trading_code` field as sometimes trading_code may duplicates so key in database may differ from trading code (e.g. CZCE futures)
2. Add `issue_price` as stock meta
3. Fix sql type
4. Add docstrings
5. Fix some bugs